### PR TITLE
Add E2E ViewModel tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,4 +77,9 @@ dependencies {
 
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.github.BlacKCaT27:CurrencyEditText:2.0.2'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.3"
+    testImplementation "org.koin:koin-test:$koin_version"
 }

--- a/app/src/test/java/com/insearching/revolutrate/RatesViewModelE2ETest.kt
+++ b/app/src/test/java/com/insearching/revolutrate/RatesViewModelE2ETest.kt
@@ -1,0 +1,99 @@
+package com.insearching.revolutrate
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.insearching.revolutrate.data.prefs.SharedPrefsHelper
+import com.insearching.revolutrate.data.repository.RatesRepository
+import com.insearching.revolutrate.fake.FakeCountriesApi
+import com.insearching.revolutrate.fake.FakeRevolutApi
+import com.insearching.revolutrate.fake.FakeSharedPreferences
+import com.insearching.revolutrate.ui.RatesViewModel
+import com.insearching.revolutrate.ui.RatesViewState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+class RatesViewModelE2ETest {
+
+    @get:Rule
+    val instantRule = InstantTaskExecutorRule()
+
+    private val dispatcher = TestCoroutineDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        startKoin {
+            modules(
+                module {
+                    single { FakeRevolutApi() }
+                    single { FakeCountriesApi() }
+                    single { SharedPrefsHelper(FakeSharedPreferences()) }
+                    single { RatesRepository(get(), get(), get()) }
+                }
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+        Dispatchers.resetMain()
+        dispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `initial load emits rates with descriptions`() = dispatcher.runBlockingTest {
+        val viewModel = RatesViewModel()
+        val states = mutableListOf<RatesViewState>()
+        val observer = { state: RatesViewState -> states.add(state) }
+        viewModel.viewStates.observeForever(observer)
+
+        // cancel repeating updater to avoid infinite loop
+        viewModel.viewModelScope.cancel()
+
+        advanceUntilIdle()
+
+        assertTrue(states.isNotEmpty())
+        val loaded = states.last()
+        assertFalse(loaded.isLoading)
+        assertEquals(3, loaded.rates.size)
+        assertEquals("US dollar", loaded.rates[0].description)
+        assertEquals("Euro", loaded.rates.first { it.title == "EUR" }.description)
+        assertEquals("British Pound", loaded.rates.first { it.title == "GBP" }.description)
+    }
+
+    @Test
+    fun `updating value recalculates rates`() = dispatcher.runBlockingTest {
+        val viewModel = RatesViewModel()
+        val states = mutableListOf<RatesViewState>()
+        val observer = { state: RatesViewState -> states.add(state) }
+        viewModel.viewStates.observeForever(observer)
+        viewModel.viewModelScope.cancel()
+
+        advanceUntilIdle()
+        states.clear()
+
+        viewModel.updateValue(2.0)
+        advanceUntilIdle()
+
+        val updated = states.last()
+        assertEquals(2.0, updated.rates[0].value)
+        assertEquals(1.8, updated.rates.first { it.title == "EUR" }.value)
+        assertEquals(1.6, updated.rates.first { it.title == "GBP" }.value)
+    }
+}

--- a/app/src/test/java/com/insearching/revolutrate/fake/FakeCountriesApi.kt
+++ b/app/src/test/java/com/insearching/revolutrate/fake/FakeCountriesApi.kt
@@ -1,0 +1,16 @@
+package com.insearching.revolutrate.fake
+
+import com.insearching.revolutrate.data.api.CountriesApi
+import com.insearching.revolutrate.data.model.CountryDetails
+import com.insearching.revolutrate.data.model.Currency
+import retrofit2.Response
+
+class FakeCountriesApi : CountriesApi {
+    override suspend fun fetchCountriesDetails(fields: String): Response<List<CountryDetails>> {
+        val countries = listOf(
+            CountryDetails(listOf(Currency("EUR", "Euro")), "EU"),
+            CountryDetails(listOf(Currency("GBP", "British Pound")), "GB")
+        )
+        return Response.success(countries)
+    }
+}

--- a/app/src/test/java/com/insearching/revolutrate/fake/FakeRevolutApi.kt
+++ b/app/src/test/java/com/insearching/revolutrate/fake/FakeRevolutApi.kt
@@ -1,0 +1,15 @@
+package com.insearching.revolutrate.fake
+
+import com.insearching.revolutrate.data.api.RevolutApi
+import com.insearching.revolutrate.data.model.DigitalRates
+import retrofit2.Response
+
+class FakeRevolutApi : RevolutApi {
+    override suspend fun latestRates(base: String): Response<DigitalRates> {
+        val rates = mapOf(
+            "EUR" to 0.9,
+            "GBP" to 0.8
+        )
+        return Response.success(DigitalRates(baseCurrency = base, rates = rates))
+    }
+}

--- a/app/src/test/java/com/insearching/revolutrate/fake/FakeSharedPreferences.kt
+++ b/app/src/test/java/com/insearching/revolutrate/fake/FakeSharedPreferences.kt
@@ -1,0 +1,38 @@
+package com.insearching.revolutrate.fake
+
+import android.content.SharedPreferences
+
+class FakeSharedPreferences : SharedPreferences {
+    private val data = mutableMapOf<String, String?>()
+
+    override fun getString(key: String?, defValue: String?): String? = data[key] ?: defValue
+
+    override fun edit(): SharedPreferences.Editor = Editor()
+
+    inner class Editor : SharedPreferences.Editor {
+        override fun putString(key: String?, value: String?): SharedPreferences.Editor {
+            data[key ?: ""] = value
+            return this
+        }
+
+        override fun apply() {}
+        override fun commit(): Boolean = true
+        override fun clear(): SharedPreferences.Editor { data.clear(); return this }
+        override fun remove(key: String?): SharedPreferences.Editor { data.remove(key); return this }
+        override fun putLong(key: String?, value: Long) = this
+        override fun putInt(key: String?, value: Int) = this
+        override fun putBoolean(key: String?, value: Boolean) = this
+        override fun putFloat(key: String?, value: Float) = this
+        override fun putStringSet(key: String?, values: MutableSet<String>?) = this
+    }
+
+    override fun contains(key: String?): Boolean = data.containsKey(key)
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean = defValue
+    override fun getInt(key: String?, defValue: Int): Int = defValue
+    override fun getAll(): MutableMap<String, *> = data
+    override fun getLong(key: String?, defValue: Long): Long = defValue
+    override fun getFloat(key: String?, defValue: Float): Float = defValue
+    override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? = defValues
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+}


### PR DESCRIPTION
## Summary
- add fake API and SharedPreferences implementations for tests
- add end-to-end ViewModel tests using Koin and coroutines test
- add unit test dependencies

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to lack of Internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6880ee7f747c83269f928e03066084ff